### PR TITLE
Improve overlap table, icons, and Google Earth preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A comprehensive GUI application for calculating pipeline lengths and analyzing o
 - **Adjustable Parameters**: Real-time parameter adjustment for different survey altitudes and equipment
 - **Cost Optimization**: Calculates effective survey length accounting for bundled sections
 - **Detailed Analytics**: Provides comprehensive breakdown of overlap statistics
+- **Google Earth Preview**: Open bundled sections directly in Google Earth with a single click
+- **Native App Icons**: Displays `.ico` on Windows and `.icns` on macOS for proper branding
 
 ### Core Features
 - Drag-and-drop file support for KMZ/KML files

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy>=1.10.0
 customtkinter>=5.0.0
 pyinstaller>=5.0.0
 tkinterdnd2
+Pillow>=9.0.0


### PR DESCRIPTION
## Summary
- Display bundled sections in a structured table with an action column
- Load platform-specific icons using Pillow for Windows/macOS branding
- Preview overlap sections in Google Earth via temporary KML files
- Document new preview and icon features and add Pillow dependency

## Testing
- `python -m py_compile src/pipeline_calculator_v3.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9048922b88333a0dca68a9020dc4c