### PR TITLE
Include Pillow in PyInstaller builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,7 @@ jobs:
         pip install numpy==1.24.3
         pip install scipy
         pip install customtkinter>=5.0.0
+        pip install Pillow>=9.0.0
         pip install pyinstaller>=5.0.0
         pip install tkinterdnd2
         
@@ -49,6 +50,7 @@ jobs:
           --hidden-import scipy.spatial \
           --hidden-import scipy._lib.messagestream \
           --hidden-import tkinterdnd2 \
+          --hidden-import PIL \
           src/pipeline_calculator_v3.py
         
         # Rename for cleaner appearance
@@ -92,6 +94,7 @@ jobs:
         pip install numpy==1.24.3
         pip install scipy
         pip install customtkinter>=5.0.0
+        pip install Pillow>=9.0.0
         pip install pyinstaller>=5.0.0
         pip install tkinterdnd2
         
@@ -104,6 +107,7 @@ jobs:
           --hidden-import scipy.spatial `
           --hidden-import scipy._lib.messagestream `
           --hidden-import tkinterdnd2 `
+          --hidden-import PIL `
           src/pipeline_calculator_v3.py
         
     - name: Upload Windows executable


### PR DESCRIPTION
## Summary
- Install Pillow during macOS and Windows workflows
- Add Pillow as a hidden import for PyInstaller on both platforms

## Testing
- `python -m py_compile src/pipeline_calculator_v3.py`
- `yamllint .github/workflows/build.yaml` *(fails: missing document start, bracket spacing, trailing spaces, indentation)*

------
https://chatgpt.com/codex/tasks/task_e_68a91e37f9fc83338c2467931fbf7201